### PR TITLE
Support for Secondary read preference

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 name = "mongodb_cwal"
 readme = "README.md"
 repository = "https://github.com/Devolutions/mongodb-cwal-rs"
-version = "0.4.0"
+version = "0.5.0"
 
 [dependencies]
 bitflags = "1.0.0"

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -187,8 +187,8 @@ impl ThreadedDatabase for Database {
     }
 
     fn auth(&self, user: &str, password: &str) -> Result<()> {
-        let authenticator = Authenticator::new(self.clone());
-        authenticator.auth(user, password)
+        let mut stream = self.client.acquire_stream(self.read_preference.clone())?.0;
+        Authenticator::new(&mut stream, self.client.clone()).auth(user, password)
     }
 
     fn collection(&self, coll_name: &str) -> Collection {

--- a/src/r2d2_mongo.rs
+++ b/src/r2d2_mongo.rs
@@ -1,6 +1,5 @@
 use crate::{
-    connstring::ConnectionString, db::ThreadedDatabase, Client, ClientOptions,
-    ThreadedClient,
+    connstring::ConnectionString, db::ThreadedDatabase, Client, ClientOptions, ThreadedClient,
 };
 
 /// A basic r2d2 connection manager for this driver.
@@ -16,9 +15,9 @@ pub struct MongoConnectionManager {
 
 impl MongoConnectionManager {
     pub fn new<S, CO>(connection_str: ConnectionString, db_name: S, client_options: CO) -> Self
-        where
-            S: Into<String>,
-            CO: Into<Option<ClientOptions>>,
+    where
+        S: Into<String>,
+        CO: Into<Option<ClientOptions>>,
     {
         Self {
             conn_str: connection_str,
@@ -33,12 +32,7 @@ impl r2d2::ManageConnection for MongoConnectionManager {
     type Error = crate::error::Error;
 
     fn connect(&self) -> Result<Self::Connection, Self::Error> {
-        let client =
-            Client::with_config(self.conn_str.clone(), self.client_options.clone(), None)?;
-        if let (Some(username), Some(password)) = (&self.conn_str.user, &self.conn_str.password)
-        {
-            client.db("admin").auth(username, password)?;
-        }
+        let client = Client::with_config(self.conn_str.clone(), self.client_options.clone(), None)?;
         Ok(client.db(&self.db_name))
     }
 


### PR DESCRIPTION
Effectively authenticates on stream creation as specified by
https://github.com/mongodb/specifications/blob/master/source/auth/auth.rst#authentication
ConnectionString is used for authentication credentials.
This fix enable usage of Secondary read preference but as a side effect user code taking advantage of the old behaviour might break.