### PR TITLE
Use `Resolver::from_system_conf()` instead of `Resolver::default()`. …

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 name = "mongodb_cwal"
 readme = "README.md"
 repository = "https://github.com/Devolutions/mongodb-cwal-rs"
-version = "0.6.2"
+version = "0.6.3"
 
 [dependencies]
 bitflags = "1.0.0"

--- a/src/connstring.rs
+++ b/src/connstring.rs
@@ -24,7 +24,7 @@ impl DNS {
 
     pub fn discover_hosts(&mut self) -> Result<()> {
         let host = format!("_mongodb._tcp.{}", self.name);
-        let srv_lookup = Resolver::default()?.lookup_srv(&host)?;
+        let srv_lookup = Resolver::from_system_conf()?.lookup_srv(&host)?;
         for srv in srv_lookup {
             self.discovered_hosts.push(Host::new(srv.target().to_utf8(), srv.port()));
         }


### PR DESCRIPTION
…This read the /etc/resolv.conf instead of defaulting the configuration to point on google's DNS servers.