### PR TITLE
Fixed warning + version bump to 0.6.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 name = "mongodb_cwal"
 readme = "README.md"
 repository = "https://github.com/Devolutions/mongodb-cwal-rs"
-version = "0.6.3"
+version = "0.6.4"
 
 [dependencies]
 bitflags = "1.0.0"

--- a/src/r2d2_mongo.rs
+++ b/src/r2d2_mongo.rs
@@ -1,4 +1,3 @@
-use common::{ReadPreference, ReadMode};
 use crate::{
     connstring::ConnectionString, db::ThreadedDatabase, Client, ClientOptions, ThreadedClient,
 };


### PR DESCRIPTION
+ take a look to https://github.com/Devolutions/mongodb-cwal-rs/commit/c41489c37d3741e7e82b6c5b0a15c7356989e675

I pushed directly on master, it was a mistake.