### PR TITLE
Implemented the use of use_cursor in AggregateOptions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 name = "mongodb_cwal"
 readme = "README.md"
 repository = "https://github.com/Devolutions/mongodb-cwal-rs"
-version = "0.6.4"
+version = "0.6.5"
 
 [dependencies]
 bitflags = "1.0.0"

--- a/src/coll/options.rs
+++ b/src/coll/options.rs
@@ -81,10 +81,12 @@ impl From<AggregateOptions> for bson::Document {
             document.insert("allowDiskUse", allow_disk_use);
         }
 
-        // useCursor not currently used by the driver.
+        let cursor = if let Some(false) = options.use_cursor {
+           doc! {}
+        } else {
+            doc! { "batchSize": options.batch_size };
+        };
 
-
-        let cursor = doc! { "batchSize": options.batch_size };
         document.insert("cursor", cursor);
 
         // maxTimeMS is not currently used by the driver.

--- a/src/coll/options.rs
+++ b/src/coll/options.rs
@@ -84,7 +84,7 @@ impl From<AggregateOptions> for bson::Document {
         let cursor = if let Some(false) = options.use_cursor {
            doc! {}
         } else {
-            doc! { "batchSize": options.batch_size };
+            doc! { "batchSize": options.batch_size }
         };
 
         document.insert("cursor", cursor);


### PR DESCRIPTION
This change has been made in a none breaking way. This has been tested with our current setup and migrations using these options have worked.