### PR TITLE
Fix compilation error with bson 0.14.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 name = "mongodb_cwal"
 readme = "README.md"
 repository = "https://github.com/Devolutions/mongodb-cwal-rs"
-version = "0.6.5"
+version = "0.6.6"
 
 [dependencies]
 bitflags = "1.0.0"

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,7 +1,7 @@
 //! Authentication schemes.
 use crate::{wire_protocol::flags::OpQueryFlags, Client};
 use bson::{
-    bson, doc,
+    doc, bson,
     spec::BinarySubtype::Generic,
     Bson::{self, Binary},
     Document,

--- a/src/coll/batch.rs
+++ b/src/coll/batch.rs
@@ -1,7 +1,7 @@
 //! Models for collection-level batch operations.
 use super::options::WriteModel;
 
-use bson::{Bson, Document, bson, doc};
+use bson::{Bson, bson, Document, doc};
 use std::convert::From;
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/coll/options.rs
+++ b/src/coll/options.rs
@@ -1,5 +1,5 @@
 //! Options for collection-level operations.
-use bson::{self, Bson, bson, doc};
+use bson::{self, bson, Bson, doc};
 use common::{ReadPreference, WriteConcern};
 use Error::ArgumentError;
 use Result;

--- a/src/common.rs
+++ b/src/common.rs
@@ -2,7 +2,7 @@
 use Error::{self, ArgumentError};
 use Result;
 
-use bson::{self, Bson, bson, doc};
+use bson::{self, bson, Bson, doc};
 use std::collections::BTreeMap;
 use std::str::FromStr;
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -68,7 +68,6 @@ use common::{ReadPreference, merge_options, WriteConcern};
 use cursor::{Cursor, DEFAULT_BATCH_SIZE};
 use self::options::{CreateCollectionOptions, CreateUserOptions, UserInfoOptions};
 use semver::Version;
-use std::error::Error;
 use std::sync::Arc;
 
 /// Interfaces with a MongoDB database.
@@ -306,7 +305,7 @@ impl ThreadedDatabase for Database {
             Some(&Bson::String(ref s)) => {
                 match Version::parse(s) {
                     Ok(v) => Ok(v),
-                    Err(e) => Err(ResponseError(String::from(e.description()))),
+                    Err(e) => Err(ResponseError(e.to_string())),
                 }
             }
             _ => Err(ResponseError(
@@ -347,7 +346,7 @@ impl ThreadedDatabase for Database {
                 doc = merge_options(doc, user_options);
             }
             None => {
-                doc.insert("roles", Vec::new());
+                doc.insert_bson("roles".to_owned(), Bson::Array(Vec::new()));
             }
         };
 

--- a/src/gridfs/file.rs
+++ b/src/gridfs/file.rs
@@ -1,5 +1,5 @@
 //! Lower-level file and chunk representations in GridFS.
-use bson::{self, Bson, bson, doc, oid};
+use bson::{self, bson, Bson, doc, oid};
 use bson::spec::BinarySubtype;
 
 use chrono::{DateTime, Utc};

--- a/src/topology/monitor.rs
+++ b/src/topology/monitor.rs
@@ -2,7 +2,7 @@
 use {Client, Result};
 use Error::{self, ArgumentError, OperationError};
 
-use bson::{self, Bson, bson, doc, oid};
+use bson::{self, bson, Bson, doc, oid};
 use chrono::{DateTime, Utc};
 
 use coll::options::FindOptions;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -40,9 +40,9 @@
 
 #[macro_use(ulps_eq)]
 extern crate approx;
-#[macro_use(bson, doc)]
+#[macro_use(doc)]
 extern crate bson;
-extern crate mongodb;
+extern crate mongodb_cwal as mongodb;
 extern crate rand;
 extern crate semver;
 #[macro_use]

--- a/tests/sdam/framework.rs
+++ b/tests/sdam/framework.rs
@@ -23,7 +23,7 @@ pub fn run_suite(file: &str, description: Option<TopologyDescription>) {
     // should pass in an unknown topology. For a base standalone topology,
     // the user should note that they expect a standalone by providing TopologyType::Single.
     let should_ignore_description = if let Some(ref inner) = description {
-        inner.topology_type == TopologyType::Single && connection_string.hosts.len() != 1
+        inner.topology_type == TopologyType::Single && connection_string.hosts.num_hosts() != 1
     } else {
         false
     };
@@ -43,7 +43,7 @@ pub fn run_suite(file: &str, description: Option<TopologyDescription>) {
     let mut servers = HashMap::new();
 
     // Fill servers array
-    for host in &connection_string.hosts {
+    for host in connection_string.hosts.iter() {
         let mut topology_description = topology.description.write().unwrap();
         let server = Server::new(
             dummy_client.clone(),


### PR DESCRIPTION
I got a compilation error when building using bson 0.14.1. This might break downstream crates as well if not fixed quickly (edit: for users without Cargo.lock or performing a `cargo update`).